### PR TITLE
Fix indentation in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,10 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
-- family-names: Stepping
-given-names: Michael
-orcid: https://orcid.org/0000-0002-5068-096X
+  - family-names: Stepping
+    given-names: Michael
+    orcid: https://orcid.org/0000-0002-5068-096X
 title: "Die Stundenplan App der EAH Jena"
 version: 1.0
---doi: 10.5281/zenodo.123456789
+doi: 10.5281/zenodo.123456789
 date-released: 2019-01-01


### PR DESCRIPTION
Some keys weren't indented correctly in CITATION.cff.
These changes have been validated with [`cffconvert`](https://pypi.org/project/cffconvert/)` --validate`.